### PR TITLE
Fix for keeping mobile-ad on place

### DIFF
--- a/index.php
+++ b/index.php
@@ -43,6 +43,7 @@
 <!-- END Google DoubleClick Code -->
 	</head>
 	<body>
+		<div id="fakemove" class="col-1 col-s-1 col-m-1 col-p-1"></div>
 		<div id="sidr">
 			<div class="col-12" id="mobile-menu"><jdoc:include type="modules" name="mobile-menu" /></div>
 		</div>
@@ -87,6 +88,7 @@
 		<script>
 			jQuery(document).ready(function () {
 				jQuery('#simple-menu').sidr({
+					body: '#fakemove'
 				});
     		});
 			jQuery(function() {

--- a/less/grid.less
+++ b/less/grid.less
@@ -5,7 +5,7 @@
 	display: block;
 }
 
-#wrapper:nth-child(3) {margin-top: 60px;}
+#wrapper:nth-child(4) {margin-top: 60px;}
 .col-p-0 {display:none;}
 .col-p-2 {width: 16.66%}
 .col-p-10 {width: 83.33%}


### PR DESCRIPTION
By using a fake small div and only using that div to be moved on
opening the menu, opening the mobile menu no longer widths the fixed
top position

Closes #82 