### PR TITLE
Normal case for titles in slide container

### DIFF
--- a/less/modules.less
+++ b/less/modules.less
@@ -151,6 +151,7 @@
 			bottom: 2em;
 			height: 2em;
 			overflow: hidden;
+			text-transform: none;
 			a {
 				color: white;
 			}


### PR DESCRIPTION
On request by Arnoud, but it’s better