### PR TITLE
Same speed for sidr and hamburger

### DIFF
--- a/js/jquery.sidr.js
+++ b/js/jquery.sidr.js
@@ -509,7 +509,7 @@
 		var transitions = helper.transitions,
 				settings = $$3.extend({
 			name: "sidr", // Name for the 'sidr'
-			speed: 200, // Accepts standard jQuery effects speeds (i.e. fast, normal or milliseconds)
+			speed: 450, // Accepts standard jQuery effects speeds (i.e. fast, normal or milliseconds)
 			side: "left", // Accepts 'left' or 'right'
 			source: null, // Override the source of the content.
 			renaming: true, // The ids and classes will be prepended with a prefix when loading existent content


### PR DESCRIPTION
Make the timing of the sidr (mobile menu) the same as the newly implemented hamburger